### PR TITLE
Fix security issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ function authenticate(options, verify) {
           return _this.fail('No auth token', next);
         }
       } else {
-        payload = jwt.decode(token, _this.options.secret, _this.options.algorithm);
+        payload = jwt.decode(token, _this.options.secret, false, _this.options.algorithm);
       }
       _this.verify(payload, verified);
     } catch (ex) {

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -24,8 +24,16 @@ describe('authenticate', function() {
       })
     });
 
-    it('should emit error when auth_token is invalid', function(done) {
+    it('should emit error when auth_token is syntactically invalid', function(done) {
       socket = io('http://localhost:9000', {query: 'auth_token=blabla', 'force new connection': true});
+      socket.on('error', function(err) {
+        expect(err).to.be.a('string');
+        done();
+      });
+    });
+
+    it('should emit error when auth_token has the wrong signature', function(done) {
+      socket = io('http://localhost:9000', {query: 'auth_token=' + data.valid_jwt_with_another_secret.token, 'force new connection': true});
       socket.on('error', function(err) {
         expect(err).to.be.a('string');
         done();

--- a/test/server/index.js
+++ b/test/server/index.js
@@ -5,7 +5,8 @@ var data = require('../testdata');
 
 exports.start = function() {
   io.use(socketIoJwtAuth.authenticate({
-    secret: data.valid_jwt.secret
+    secret: data.valid_jwt.secret,
+    algorithm: 'HS256'
   }, function(payload, done) {
     var id = payload.sub;
     if (!id) {

--- a/test/testdata.js
+++ b/test/testdata.js
@@ -6,6 +6,13 @@ module.exports = {
     },
     secret: 'secret'
   },
+  valid_jwt_with_another_secret: {
+    token: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.rbRUk2g1Rifi3klfYOV6Z1unf3xfRWMRP8JBIHVDYzw',
+    payload: {
+      'sub': '1'
+    },
+    secret: 'anothersecret'
+  },
   user: {
     name: 'leilei',
     email: 'adcentury100@gmail.com'


### PR DESCRIPTION
Unfortunately `node-jwt-simple` has not a good api. The third argument is used to allow decoding token without verify its signature, and right now the `algorithm` is passed to it.
This mean that if you've specified the `algorithm` like this:

```
jwtAuth.authenticate({
  secret: 'Your Secret',  
  algorithm: 'HS256' // this in a boolean context is evaluated truthy
}, ...
```

you aren't verifying the signature of your tokens. This PR should fix that.