### PR TITLE
Error handling to include message on socket error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,9 +23,18 @@ function authenticate(options, verify) {
   }
 
   this.fail = function(err, next) {
-    // Socket IO parser only parses object if there is a data field
-    err.data = { name: error, message: err.message }; 
-    next(err);
+    var error;
+    // Legacy support for users who handle the errors as strings
+    // Should be removed on next release.
+    if (typeof(err) === 'string') {
+      error = new Error(err);
+    } else {
+      // Socket IO parser only parses object if there is a data field
+      // This allows for better error handling by checking name/type
+      error = err;
+      error.data = { name: err.name, message: err.message };
+    }
+    next(error);
   }
 
   return function(socket, next) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,9 @@ function authenticate(options, verify) {
   }
 
   this.fail = function(err, next) {
-    next(new Error(err));
+    // Socket IO parser only parses object if there is a data field
+    err.data = { name: error, message: err.message }; 
+    next(err);
   }
 
   return function(socket, next) {

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -19,7 +19,7 @@ describe('authenticate', function() {
     it('should emit error when auth_token is missing', function(done) {
       socket = io('http://localhost:9000', {'force new connection': true});
       socket.on('error', function(err) {
-        expect(err.message).to.equal('No auth token');
+        expect(err).to.equal('No auth token');
         done();
       })
     });
@@ -41,7 +41,7 @@ describe('authenticate', function() {
       socket.on('error', function(err) {
         expect(err).to.be.a('object');
         expect(err.message).to.be.a('string')
-        expect(err.message).to.equal('Not enough or too many segments');
+        expect(err.message).to.equal('Signature verification failed');
         expect(err.name).to.equal('Error')
         done();
       });

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -19,7 +19,7 @@ describe('authenticate', function() {
     it('should emit error when auth_token is missing', function(done) {
       socket = io('http://localhost:9000', {'force new connection': true});
       socket.on('error', function(err) {
-        expect(err).to.equal('No auth token');
+        expect(err.message).to.equal('No auth token');
         done();
       })
     });
@@ -27,7 +27,11 @@ describe('authenticate', function() {
     it('should emit error when auth_token is syntactically invalid', function(done) {
       socket = io('http://localhost:9000', {query: 'auth_token=blabla', 'force new connection': true});
       socket.on('error', function(err) {
-        expect(err).to.be.a('string');
+        expect(err).to.be.a('object');
+        expect(err.message).to.be.a('string')
+        expect(err.message).to.equal('Not enough or too many segments');
+        expect(err.name).to.equal('Error')
+      
         done();
       });
     });
@@ -35,7 +39,10 @@ describe('authenticate', function() {
     it('should emit error when auth_token has the wrong signature', function(done) {
       socket = io('http://localhost:9000', {query: 'auth_token=' + data.valid_jwt_with_another_secret.token, 'force new connection': true});
       socket.on('error', function(err) {
-        expect(err).to.be.a('string');
+        expect(err).to.be.a('object');
+        expect(err.message).to.be.a('string')
+        expect(err.message).to.equal('Not enough or too many segments');
+        expect(err.name).to.equal('Error')
         done();
       });
     });


### PR DESCRIPTION
Currently we can only ever send back a string to the user which doesn't allow for good error handling.  If we add a data field Socket io's parser handles parsing an object (https://github.com/socketio/socket.io-parser/blob/master/index.js#L169)