### PR TITLE
Feature/support token in header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 lib-cov/
 coverage.json
 npm-debug.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ io.listen(9000);
 </script>
 ```
 
+If your client [support](https://socket.io/docs/client-api/#With-extraHeaders), you can also choose to pass the auth token in headers.
+
+```javascript
+<script>
+  // Use extraHeaders to set a custom header, the key is 'x-auth-token'.
+  // Don't forget to replace THE_JWT_TOKEN with the valid one.
+  var socket = io('http://localhost:9000', {
+    extraHeaders: {
+      'x-auth-token': 'THE_JWT_TOKEN'
+    },
+    transportOptions: {
+      polling: {
+        extraHeaders: {
+          'x-auth-token': 'THE_JWT_TOKEN'
+        }
+      }
+    },
+  });
+  // ...
+</script>
+```
+
 ## Tests
 
 ```
@@ -132,6 +154,10 @@ npm test
 ```
 
 ## Change Log
+
+### 0.1.0
+
+* Add support for passing auth token with `extraHeaders`
 
 ### 0.0.6
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function authenticate(options, verify) {
   }
 
   return function(socket, next) {
-    var token = socket.handshake.query.auth_token;
+    var token = socket.handshake.headers['x-auth-token'] || socket.handshake.query.auth_token;
     var verified = function(err, user, message) {
       if (err) {
         return _this.fail(err, next);

--- a/test/authenticate.test.js
+++ b/test/authenticate.test.js
@@ -56,7 +56,30 @@ describe('authenticate', function() {
         expect(user.logged_in).to.be.true;
         done();
       });
-    })
+    });
+
+    it('should support auth token being passed in with extraHeaders', function(done) {
+      socket = io('http://localhost:9000', {
+        extraHeaders: {
+          'x-auth-token': data.valid_jwt.token
+        },
+        transportOptions: {
+          polling: {
+            extraHeaders: {
+              'x-auth-token': data.valid_jwt.token
+            }
+          }
+        },
+        'force new connection': true
+      });
+      socket.on('success', function(user) {
+        expect(user).to.be.an('object');
+        expect(user.name).to.equal(data.user.name);
+        expect(user.email).to.equal(data.user.email);
+        expect(user.logged_in).to.be.true;
+        done();
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Add support for passing auth token with `extraHeaders`.

Solve #13 