### PR TITLE
Added optional socket.handshake.auth.auth_token token path for socket io v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ io.listen(9000);
   // You should add auth_token to the query when connecting
   // Replace THE_JWT_TOKEN with the valid one
   var socket = io('http://localhost:9000', {query: 'auth_token=THE_JWT_TOKEN'});
+  // For socket.io v3 you must use 'auth' object in place of 'query'
+  // var socket = io('http://localhost:9000', {auth: 'auth_token=THE_JWT_TOKEN'});
   // Connection failed
   socket.on('error', function(err) {
     throw new Error(err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function authenticate(options, verify) {
   }
 
   return function(socket, next) {
-    var token = socket.handshake.headers['x-auth-token'] || socket.handshake.query.auth_token;
+    var token = socket.handshake.headers['x-auth-token'] || socket.handshake.query.auth_token || socket.handshake.auth.auth_token;
     var verified = function(err, user, message) {
       if (err) {
         return _this.fail(err, next);


### PR DESCRIPTION
Tests not amended as would require socket.io v3 upgrade in package.json which would not be backwardly compatible.